### PR TITLE
Bug: Fix bad CI trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,5 @@ jobs:
           build-platform: ${{ matrix.build.platform }}
 on:
   push:
-    branches:
-      - main
     tags:
       - v*


### PR DESCRIPTION
The release job was being triggered on merges to the main branch. That's wasteful.