### PR TITLE
Fix: Double runs of release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,12 +39,9 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist
-          package: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 on:
   push:
-    branches:
-      - 'main'
     tags:
       - 'v*'


### PR DESCRIPTION
GitHub Actions have some contradictory documentation about triggering releases. Based on the configuration change, tags will be targeted that start with `v`. I was hoping to also limit this to tags on the `main` branch but that doesn't seem to be possible.